### PR TITLE
Disable group syncing from crowd server

### DIFF
--- a/src/main/java/org/sonar/plugins/crowd/CrowdConfiguration.java
+++ b/src/main/java/org/sonar/plugins/crowd/CrowdConfiguration.java
@@ -32,6 +32,7 @@ public class CrowdConfiguration implements ServerExtension {
   static final String KEY_CROWD_APP_NAME = "crowd.application";
   static final String KEY_CROWD_APP_PASSWORD = "crowd.password";
   static final String FALLBACK_NAME = "sonar";
+  static final String KEY_CROWD_GRP_SYNC = "crowd.groups.sync";
   private final Settings settings;
 
   /**
@@ -81,5 +82,13 @@ public class CrowdConfiguration implements ServerExtension {
    */
   public String getCrowdUrl() {
     return getAndValidate(KEY_CROWD_URL, settings);
+  }
+  
+  /**
+   * Define if the Groups have to be synced from the Crowd server.
+   * Defaults to true if not provided.
+   */
+  public String getCrowdGrpSync() {
+      return get(KEY_CROWD_GRP_SYNC, settings, "true");
   }
 }

--- a/src/main/java/org/sonar/plugins/crowd/CrowdRealm.java
+++ b/src/main/java/org/sonar/plugins/crowd/CrowdRealm.java
@@ -113,7 +113,12 @@ public class CrowdRealm extends SecurityRealm {
 
   @Override
   public ExternalGroupsProvider getGroupsProvider() {
-    return groupsProvider;
+        if(this.crowdConfiguration.getCrowdGrpSync() == "true") {
+            LOG.debug("Sync group from Crowd enabled.");
+            return groupsProvider;
+        }
+        LOG.debug("Sync groups from Crowd disabled.");
+        return null;
   }
 
   @Override


### PR DESCRIPTION
Added new key for the sonar.properties file:
crowd.groups.sync (true/false)
If false, the groups are not synced from the crowd server.
Defaults to true.